### PR TITLE
Add library export for internal usage while maintaining server compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@villagemetrics/ask-anything-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Model Context Protocol server for Village Metrics behavioral tracking data access",
   "type": "module",
-  "main": "src/index.js",
+  "main": "src/lib/index.js",
+  "exports": {
+    ".": "./src/lib/index.js",
+    "./server": "./src/index.js"
+  },
   "bin": {
     "ask-anything-mcp": "./src/index.js"
   },

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,10 @@
+// Export core library functionality
+export { MCPCore } from './mcpCore.js';
+
+// Re-export useful components for advanced usage
+export { ToolRegistry } from '../tools/registry.js';
+export { SessionManager } from '../session/sessionManager.js';
+export { TokenValidator } from '../auth/tokenValidator.js';
+
+// Export utility functions
+export { createLogger } from '../utils/logger.js';

--- a/src/lib/mcpCore.js
+++ b/src/lib/mcpCore.js
@@ -1,0 +1,215 @@
+import { createLogger } from '../utils/logger.js';
+import { ToolRegistry } from '../tools/registry.js';
+import { SessionManager } from '../session/sessionManager.js';
+import { TokenValidator } from '../auth/tokenValidator.js';
+
+const logger = createLogger('MCPCore');
+
+/**
+ * Core MCP functionality that can be used as a library
+ * Independent of the MCP server transport layer
+ */
+export class MCPCore {
+  constructor(options = {}) {
+    this.options = {
+      // Default configuration
+      loggerName: 'MCPCore',
+      enableTokenValidation: true,
+      bypassApiValidation: false, // Allow bypassing API token requirements for internal usage
+      ...options
+    };
+    
+    this.tokenValidator = new TokenValidator();
+    this.sessionManager = new SessionManager();
+    
+    // For internal usage, we can bypass API validation
+    if (this.options.bypassApiValidation) {
+      // Set a dummy token to bypass VMApiClient validation
+      process.env.VM_MCP_TOKEN = process.env.VM_MCP_TOKEN || 'internal-bypass-token';
+    }
+    
+    this.toolRegistry = new ToolRegistry(this.sessionManager, this.tokenValidator);
+    this.sessionId = null;
+    this.userContext = null;
+    
+    logger.info('MCP Core initialized', this.options);
+  }
+
+  /**
+   * Initialize with token validation (for external usage)
+   * @param {string} token - MCP token
+   * @returns {Promise<Object>} User context and session ID
+   */
+  async initializeWithToken(token) {
+    if (!token) {
+      throw new Error('Token is required for MCP Core initialization');
+    }
+
+    try {
+      this.userContext = await this.tokenValidator.validateToken(token);
+      this.sessionId = this.sessionManager.createSession(this.userContext.userId);
+      
+      logger.info('MCP Core initialized with token', { 
+        userId: this.userContext.userId, 
+        sessionId: this.sessionId 
+      });
+      
+      return { userContext: this.userContext, sessionId: this.sessionId };
+    } catch (error) {
+      logger.error('Token validation failed', { error: error.message });
+      throw new Error(`Invalid token: ${error.message}`);
+    }
+  }
+
+  /**
+   * Initialize with existing user context (for internal usage)
+   * @param {Object} userContext - Pre-validated user context
+   * @returns {string} Session ID
+   */
+  initializeWithUserContext(userContext) {
+    if (!userContext || !userContext.userId) {
+      throw new Error('Valid user context with userId is required');
+    }
+
+    this.userContext = userContext;
+    this.sessionId = this.sessionManager.createSession(this.userContext.userId);
+    
+    logger.info('MCP Core initialized with user context', { 
+      userId: this.userContext.userId, 
+      sessionId: this.sessionId 
+    });
+    
+    return this.sessionId;
+  }
+
+  /**
+   * Get available tool definitions
+   * @returns {Array} Array of tool definitions
+   */
+  getAvailableTools() {
+    return this.toolRegistry.getToolDefinitions();
+  }
+
+  /**
+   * Execute a tool
+   * @param {string} toolName - Name of the tool to execute
+   * @param {Object} args - Arguments for the tool
+   * @returns {Promise<any>} Tool execution result
+   */
+  async executeTool(toolName, args = {}) {
+    if (!this.sessionId) {
+      throw new Error('MCP Core not initialized. Call initializeWithToken() or initializeWithUserContext() first.');
+    }
+
+    logger.debug('Executing tool', { tool: toolName, args, sessionId: this.sessionId });
+
+    try {
+      const result = await this.toolRegistry.executeTool(toolName, args, this.sessionId);
+      logger.debug('Tool executed successfully', { tool: toolName });
+      return result;
+    } catch (error) {
+      logger.error('Tool execution failed', { 
+        tool: toolName, 
+        error: error.message,
+        args 
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Execute multiple tools in sequence
+   * @param {Array} toolCalls - Array of {name, arguments} objects
+   * @returns {Promise<Array>} Array of results
+   */
+  async executeTools(toolCalls) {
+    if (!Array.isArray(toolCalls)) {
+      throw new Error('toolCalls must be an array');
+    }
+
+    const results = [];
+    for (const toolCall of toolCalls) {
+      try {
+        const result = await this.executeTool(toolCall.name, toolCall.arguments);
+        results.push({
+          toolName: toolCall.name,
+          success: true,
+          result
+        });
+      } catch (error) {
+        results.push({
+          toolName: toolCall.name,
+          success: false,
+          error: error.message
+        });
+      }
+    }
+    
+    return results;
+  }
+
+  /**
+   * Get session information
+   * @returns {Object} Session details
+   */
+  getSession() {
+    if (!this.sessionId) {
+      throw new Error('MCP Core not initialized');
+    }
+    
+    return this.sessionManager.getSession(this.sessionId);
+  }
+
+  /**
+   * Update session data
+   * @param {Object} updates - Updates to apply to session
+   * @returns {Object} Updated session
+   */
+  updateSession(updates) {
+    if (!this.sessionId) {
+      throw new Error('MCP Core not initialized');
+    }
+    
+    return this.sessionManager.updateSession(this.sessionId, updates);
+  }
+
+  /**
+   * Set selected child for the session
+   * @param {string} childId - Child ID
+   * @param {string} childName - Child name
+   * @returns {Object} Updated session
+   */
+  setSelectedChild(childId, childName) {
+    if (!this.sessionId) {
+      throw new Error('MCP Core not initialized');
+    }
+    
+    return this.sessionManager.setSelectedChild(this.sessionId, childId, childName);
+  }
+
+  /**
+   * Get selected child for the session
+   * @returns {Object} Selected child info
+   */
+  getSelectedChild() {
+    if (!this.sessionId) {
+      throw new Error('MCP Core not initialized');
+    }
+    
+    return this.sessionManager.getSelectedChild(this.sessionId);
+  }
+
+  /**
+   * Clean up session data
+   */
+  cleanup() {
+    if (this.sessionId) {
+      // Remove this specific session
+      this.sessionManager.sessions.delete(this.sessionId);
+      logger.info('Session cleaned up', { sessionId: this.sessionId });
+    }
+    
+    this.sessionId = null;
+    this.userContext = null;
+  }
+}

--- a/test/lib/mcpCore.test.js
+++ b/test/lib/mcpCore.test.js
@@ -1,0 +1,188 @@
+import { expect } from 'chai';
+import { MCPCore } from '../../src/lib/mcpCore.js';
+
+describe('MCPCore Library', function() {
+  let mcpCore;
+  
+  beforeEach(function() {
+    mcpCore = new MCPCore();
+  });
+  
+  afterEach(function() {
+    if (mcpCore) {
+      mcpCore.cleanup();
+    }
+  });
+
+  describe('Initialization', function() {
+    it('should create MCPCore instance', function() {
+      expect(mcpCore).to.be.instanceOf(MCPCore);
+      expect(mcpCore.sessionId).to.be.null;
+      expect(mcpCore.userContext).to.be.null;
+    });
+
+    it('should initialize with user context for internal usage', function() {
+      const userContext = {
+        userId: 'test-user-123',
+        userName: 'Test User'
+      };
+      
+      const sessionId = mcpCore.initializeWithUserContext(userContext);
+      
+      expect(sessionId).to.be.a('string');
+      expect(sessionId).to.include('session_');
+      expect(mcpCore.sessionId).to.equal(sessionId);
+      expect(mcpCore.userContext).to.deep.equal(userContext);
+    });
+
+    it('should throw error when initializing with invalid user context', function() {
+      expect(() => {
+        mcpCore.initializeWithUserContext(null);
+      }).to.throw('Valid user context with userId is required');
+
+      expect(() => {
+        mcpCore.initializeWithUserContext({});
+      }).to.throw('Valid user context with userId is required');
+    });
+  });
+
+  describe('Tool Management', function() {
+    beforeEach(function() {
+      const userContext = { userId: 'test-user-123' };
+      mcpCore.initializeWithUserContext(userContext);
+    });
+
+    it('should get available tools', function() {
+      const tools = mcpCore.getAvailableTools();
+      
+      expect(tools).to.be.an('array');
+      expect(tools.length).to.be.greaterThan(0);
+      
+      // Check that each tool has required properties
+      tools.forEach(tool => {
+        expect(tool).to.have.property('name');
+        expect(tool).to.have.property('description');
+        expect(tool).to.have.property('inputSchema');
+      });
+      
+      // Check for some expected tools
+      const toolNames = tools.map(t => t.name);
+      expect(toolNames).to.include('list_children');
+      expect(toolNames).to.include('get_behavior_scores');
+      expect(toolNames).to.include('search_journal_entries');
+    });
+
+    it('should throw error when executing tool without initialization', async function() {
+      const uninitializedCore = new MCPCore();
+      
+      try {
+        await uninitializedCore.executeTool('listChildren');
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error.message).to.include('MCP Core not initialized');
+      }
+    });
+
+    it('should throw error for non-existent tool', async function() {
+      try {
+        await mcpCore.executeTool('nonExistentTool');
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error.message).to.include('Tool not found');
+      }
+    });
+
+    it('should execute multiple tools in sequence', async function() {
+      const toolCalls = [
+        { name: 'listChildren', arguments: {} },
+        { name: 'getBehaviorScores', arguments: { date: '2025-01-15' } }
+      ];
+      
+      const results = await mcpCore.executeTools(toolCalls);
+      
+      expect(results).to.be.an('array');
+      expect(results.length).to.equal(2);
+      
+      results.forEach((result, index) => {
+        expect(result).to.have.property('toolName', toolCalls[index].name);
+        expect(result).to.have.property('success');
+        
+        if (result.success) {
+          expect(result).to.have.property('result');
+        } else {
+          expect(result).to.have.property('error');
+        }
+      });
+    });
+
+    it('should handle invalid toolCalls parameter', async function() {
+      try {
+        await mcpCore.executeTools('not-an-array');
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error.message).to.include('toolCalls must be an array');
+      }
+    });
+  });
+
+  describe('Session Management', function() {
+    beforeEach(function() {
+      const userContext = { userId: 'test-user-123' };
+      mcpCore.initializeWithUserContext(userContext);
+    });
+
+    it('should get session information', function() {
+      const session = mcpCore.getSession();
+      
+      expect(session).to.be.an('object');
+      expect(session).to.have.property('sessionId');
+      expect(session).to.have.property('userId', 'test-user-123');
+      expect(session).to.have.property('selectedChildId', null);
+      expect(session).to.have.property('createdAt');
+      expect(session).to.have.property('lastActivity');
+    });
+
+    it('should update session data', function() {
+      const updates = { customData: 'test-value' };
+      const updatedSession = mcpCore.updateSession(updates);
+      
+      expect(updatedSession).to.have.property('customData', 'test-value');
+    });
+
+    it('should set and get selected child', function() {
+      const childId = 'child-123';
+      const childName = 'Test Child';
+      
+      const updatedSession = mcpCore.setSelectedChild(childId, childName);
+      expect(updatedSession).to.have.property('selectedChildId', childId);
+      expect(updatedSession).to.have.property('selectedChildName', childName);
+      
+      const selectedChild = mcpCore.getSelectedChild();
+      expect(selectedChild).to.deep.equal({
+        childId: childId,
+        childName: childName
+      });
+    });
+
+    it('should throw error when getting selected child if none selected', function() {
+      expect(() => {
+        mcpCore.getSelectedChild();
+      }).to.throw('No child selected');
+    });
+  });
+
+  describe('Cleanup', function() {
+    it('should clean up session data', function() {
+      const userContext = { userId: 'test-user-123' };
+      const sessionId = mcpCore.initializeWithUserContext(userContext);
+      
+      expect(mcpCore.sessionId).to.equal(sessionId);
+      expect(mcpCore.userContext).to.deep.equal(userContext);
+      
+      mcpCore.cleanup();
+      
+      expect(mcpCore.sessionId).to.be.null;
+      expect(mcpCore.userContext).to.be.null;
+    });
+  });
+});


### PR DESCRIPTION
- Add MCPCore class for programmatic usage independent of MCP transport
- Export library components via src/lib/index.js
- Add bypassApiValidation option for internal system usage
- Update package.json exports for dual server/library usage
- Add comprehensive test suite for library functionality
- Maintain full backwards compatibility with existing MCP server

Enables integration with ask-anything-engine ChatOrchestrator while preserving standalone MCP server functionality.