### PR TITLE
Migrate to @villagemetrics-public scope and add library usage support

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Publish to NPM
         if: steps.check_version.outputs.should_publish == 'true'
-        run: npm publish
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -335,7 +335,7 @@ For testing, you need a real MCP token from Village Metrics:
   "mcpServers": {
     "ask-anything": {
       "command": "npx",
-      "args": ["@villagemetrics/ask-anything-mcp"],
+      "args": ["@villagemetrics-public/ask-anything-mcp"],
       "env": {
         "VM_MCP_TOKEN": "<token_from_app>"
       }
@@ -380,7 +380,7 @@ describe('MCP Server', () => {
 ### 10.1 NPM Package
 ```json
 {
-  "name": "@villagemetrics/ask-anything-mcp",
+  "name": "@villagemetrics-public/ask-anything-mcp",
   "version": "1.0.0",
   "bin": {
     "ask-anything-mcp": "./src/index.js"
@@ -397,10 +397,10 @@ describe('MCP Server', () => {
 ### 10.2 Usage Instructions
 ```bash
 # Install globally
-npm install -g @villagemetrics/ask-anything-mcp
+npm install -g @villagemetrics-public/ask-anything-mcp
 
 # Or use directly with npx
-npx @villagemetrics/ask-anything-mcp
+npx @villagemetrics-public/ask-anything-mcp
 ```
 
 ## 11. Security Considerations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@villagemetrics/ask-anything-mcp",
-  "version": "0.1.1",
+  "name": "@villagemetrics-public/ask-anything-mcp",
+  "version": "0.1.2",
   "description": "Model Context Protocol server for Village Metrics behavioral tracking data access",
   "type": "module",
   "main": "src/lib/index.js",

--- a/src/lib/mcpCore.js
+++ b/src/lib/mcpCore.js
@@ -22,10 +22,10 @@ export class MCPCore {
     this.tokenValidator = new TokenValidator();
     this.sessionManager = new SessionManager();
     
-    // For internal usage, we can bypass API validation
-    if (this.options.bypassApiValidation) {
-      // Set a dummy token to bypass VMApiClient validation
-      process.env.VM_MCP_TOKEN = process.env.VM_MCP_TOKEN || 'internal-bypass-token';
+    // For internal usage, ensure VM_MCP_TOKEN is available
+    // The token should come from environment (e.g., .env.secrets.local)
+    if (this.options.bypassApiValidation && !process.env.VM_MCP_TOKEN) {
+      logger.warn('VM_MCP_TOKEN not found in environment. API calls will fail with 401.');
     }
     
     this.toolRegistry = new ToolRegistry(this.sessionManager, this.tokenValidator);


### PR DESCRIPTION
- Update package name from @villagemetrics/ask-anything-mcp to @villagemetrics-public/ask-anything-mcp
- Bump version to 0.1.2
- Add library import capability to MCPCore with bypassApiValidation option
- Update all documentation references to new package name
- Fix GitHub Actions workflow to use --access public for scoped package publishing