### PR TITLE
feat: add schemaOnly mode for tokenless tool schema extraction

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -27,7 +27,9 @@ npm install
 ```bash
 # Set your MCP token
 export VM_MCP_TOKEN="vm_mcp_a1b2_c3d4_e5f6_g7h8"  # Your MCP token from step 1
-export VM_API_BASE_URL="https://api-dev.villagemetrics.com"
+
+# Optional: Set API URL (defaults to production)
+export VM_API_BASE_URL="https://api-dev.villagemetrics.com"  # Only if testing against dev API
 
 # Run the manual test script
 npm run test:manual
@@ -57,7 +59,7 @@ Add to your Claude Desktop config file:
       "args": ["/Users/YOUR_USERNAME/devel/vm/ask-anything-mcp/src/index.js"],
       "env": {
         "VM_MCP_TOKEN": "vm_mcp_xxxx_xxxx_xxxx_xxxx",
-        "VM_API_BASE_URL": "https://api-dev.villagemetrics.com"
+        "VM_API_BASE_URL": "https://api.villagemetrics.com"
       }
     }
   }
@@ -81,7 +83,7 @@ If you see "Invalid token" errors:
 1. **Check token expiration**: MCP tokens expire based on your selected period (90 days, 1 year, 2 years)
 2. **Generate a new token**: Go to Settings → Connect AI Tools in the Village Metrics app
 3. **Verify token format**: Should start with `vm_mcp_` (MCP token format)
-4. **Check API URL**: Make sure you're using `api-dev.villagemetrics.com` for dev tokens
+4. **Check API URL**: Defaults to production API. For dev testing, add `VM_API_BASE_URL=https://api-dev.villagemetrics.com` to your environment
 
 ### Connection Issues  
 If Claude can't connect to MCP:

--- a/docs/design.md
+++ b/docs/design.md
@@ -306,8 +306,8 @@ async function handleToolCall(toolName, args) {
 
 ### 8.1 Environment Variables
 ```bash
-# Required
-VM_API_BASE_URL=https://api-dev.villagemetrics.com  # Full URL (api-dev for dev, api for prod)
+# Optional - defaults to production
+VM_API_BASE_URL=https://api.villagemetrics.com  # Full URL (defaults to production, use api-dev.villagemetrics.com for dev)
 VM_MCP_TOKEN=<user_mcp_token>  # User's MCP token from Village Metrics app
 
 # Optional

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villagemetrics-public/ask-anything-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Model Context Protocol server for Village Metrics behavioral tracking data access",
   "type": "module",
   "main": "src/lib/index.js",

--- a/src/auth/tokenValidator.js
+++ b/src/auth/tokenValidator.js
@@ -5,7 +5,7 @@ const logger = createLogger('TokenValidator');
 
 export class TokenValidator {
   constructor() {
-    this.apiBaseUrl = process.env.VM_API_BASE_URL || 'https://api-dev.villagemetrics.com';
+    this.apiBaseUrl = process.env.VM_API_BASE_URL || 'https://api.villagemetrics.com';
   }
 
   async validateToken(token) {

--- a/src/clients/vmApiClient.js
+++ b/src/clients/vmApiClient.js
@@ -5,7 +5,7 @@ const logger = createLogger('VMApiClient');
 
 export class VMApiClient {
   constructor() {
-    this.baseUrl = process.env.VM_API_BASE_URL || 'https://api-dev.villagemetrics.com';
+    this.baseUrl = process.env.VM_API_BASE_URL || 'https://api.villagemetrics.com';
     this.token = process.env.VM_MCP_TOKEN;
     
     if (!this.token) {

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,26 @@ async function main() {
 
 main().catch((error) => {
   logger.error('Failed to start MCP server', { error: error.message, stack: error.stack });
-  process.stderr.write(`FATAL ERROR: Failed to start MCP server - ${error.message}\n`);
+  
+  process.stderr.write(`\nFATAL ERROR: MCP Server crashed during startup\n`);
+  process.stderr.write(`Reason: ${error.message}\n`);
+  
+  if (error.message.includes('ECONNREFUSED') || error.message.includes('fetch')) {
+    process.stderr.write(`\nThis appears to be a network/API connection issue.\n`);
+    process.stderr.write(`Please check:\n`);
+    process.stderr.write(`1. VM_API_BASE_URL is set correctly: ${process.env.VM_API_BASE_URL}\n`);
+    process.stderr.write(`2. You have internet connectivity\n`);
+    process.stderr.write(`3. The Village Metrics API is accessible\n\n`);
+  } else if (error.message.includes('node') || error.message.includes('binary')) {
+    process.stderr.write(`\nThis appears to be a Node.js compatibility issue.\n`);
+    process.stderr.write(`Please check:\n`);
+    process.stderr.write(`1. You're using Node.js 18 or later\n`);
+    process.stderr.write(`2. Your Node.js installation is compatible with your system architecture\n`);
+    process.stderr.write(`3. Try running: npx @villagemetrics-public/ask-anything-mcp directly in terminal\n\n`);
+  }
+  
+  process.stderr.write(`Full error details:\n${error.stack}\n\n`);
+  process.stderr.write(`For more help, visit: https://github.com/villagemetrics/ask-anything-mcp/issues\n`);
+  
   process.exit(1);
 });

--- a/src/lib/mcpCore.js
+++ b/src/lib/mcpCore.js
@@ -2,6 +2,11 @@ import { createLogger } from '../utils/logger.js';
 import { ToolRegistry } from '../tools/registry.js';
 import { SessionManager } from '../session/sessionManager.js';
 import { TokenValidator } from '../auth/tokenValidator.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const logger = createLogger('MCPCore');
 
@@ -16,23 +21,33 @@ export class MCPCore {
       loggerName: 'MCPCore',
       enableTokenValidation: true,
       bypassApiValidation: false, // Allow bypassing API token requirements for internal usage
+      schemaOnly: false, // Only provide tool schemas without initializing tool instances
       ...options
     };
     
-    this.tokenValidator = new TokenValidator();
-    this.sessionManager = new SessionManager();
-    
-    // For internal usage, ensure VM_MCP_TOKEN is available
-    // The token should come from environment (e.g., .env.secrets.local)
-    if (this.options.bypassApiValidation && !process.env.VM_MCP_TOKEN) {
-      logger.warn('VM_MCP_TOKEN not found in environment. API calls will fail with 401.');
-    }
-    
-    this.toolRegistry = new ToolRegistry(this.sessionManager, this.tokenValidator);
     this.sessionId = null;
     this.userContext = null;
     
-    logger.info('MCP Core initialized', this.options);
+    if (this.options.schemaOnly) {
+      // Schema-only mode: just provide tool definitions without VM API client dependencies
+      this.toolRegistry = null; // No tool instances
+      this.tokenValidator = null;
+      this.sessionManager = null;
+      logger.info('MCP Core initialized in schema-only mode (no token required)', this.options);
+    } else {
+      // Full mode: initialize everything
+      this.tokenValidator = new TokenValidator();
+      this.sessionManager = new SessionManager();
+      
+      // For internal usage, ensure VM_MCP_TOKEN is available
+      // The token should come from environment (e.g., .env.secrets.local)
+      if (this.options.bypassApiValidation && !process.env.VM_MCP_TOKEN) {
+        logger.warn('VM_MCP_TOKEN not found in environment. API calls will fail with 401.');
+      }
+      
+      this.toolRegistry = new ToolRegistry(this.sessionManager, this.tokenValidator);
+      logger.info('MCP Core initialized in full mode', this.options);
+    }
   }
 
   /**
@@ -84,10 +99,73 @@ export class MCPCore {
 
   /**
    * Get available tool definitions
-   * @returns {Array} Array of tool definitions
+   * @returns {Promise<Array>|Array} Array of tool definitions (Promise in schema-only mode)
    */
   getAvailableTools() {
+    if (this.options.schemaOnly) {
+      // Return promise for static tool definitions without initializing tool instances
+      return this.getStaticToolDefinitions();
+    }
     return this.toolRegistry.getToolDefinitions();
+  }
+
+  /**
+   * Get static tool definitions for schema-only mode
+   * Auto-discover all tool classes in the tools directory
+   * @returns {Promise<Array>} Array of static tool definitions
+   */
+  async getStaticToolDefinitions() {
+    const toolsDir = path.join(__dirname, '../tools');
+    const toolDefinitions = [];
+    
+    // Recursively find all .js files in the tools directory
+    const findToolFiles = (dir) => {
+      const files = [];
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          files.push(...findToolFiles(fullPath));
+        } else if (entry.isFile() && entry.name.endsWith('.js') && entry.name !== 'registry.js') {
+          files.push(fullPath);
+        }
+      }
+      
+      return files;
+    };
+    
+    const toolFiles = findToolFiles(toolsDir);
+    
+    // Dynamically import each tool file and extract its definition
+    for (const toolFile of toolFiles) {
+      try {
+        const relativePath = path.relative(__dirname, toolFile);
+        const importPath = './' + relativePath.replace(/\\/g, '/'); // Normalize path separators
+        
+        const module = await import(importPath);
+        
+        // Find the tool class (look for exports that have a definition property)
+        for (const exportName of Object.keys(module)) {
+          const exportedClass = module[exportName];
+          if (exportedClass && exportedClass.definition) {
+            const definition = exportedClass.definition;
+            toolDefinitions.push({
+              name: definition.name,
+              description: definition.description,
+              inputSchema: definition.inputSchema
+            });
+            break; // Only take the first tool class per file
+          }
+        }
+      } catch (error) {
+        // Log warning but don't fail - some files might not be tool classes
+        logger.warn(`Failed to import tool from ${toolFile}`, { error: error.message });
+      }
+    }
+    
+    logger.info(`Auto-discovered ${toolDefinitions.length} tool definitions`);
+    return toolDefinitions;
   }
 
   /**
@@ -97,6 +175,10 @@ export class MCPCore {
    * @returns {Promise<any>} Tool execution result
    */
   async executeTool(toolName, args = {}) {
+    if (this.options.schemaOnly) {
+      throw new Error(`Cannot execute tools in schema-only mode. Tool '${toolName}' requires full MCP Core initialization.`);
+    }
+
     if (!this.sessionId) {
       throw new Error('MCP Core not initialized. Call initializeWithToken() or initializeWithUserContext() first.');
     }
@@ -123,6 +205,10 @@ export class MCPCore {
    * @returns {Promise<Array>} Array of results
    */
   async executeTools(toolCalls) {
+    if (this.options.schemaOnly) {
+      throw new Error('Cannot execute tools in schema-only mode. Tools require full MCP Core initialization.');
+    }
+
     if (!Array.isArray(toolCalls)) {
       throw new Error('toolCalls must be an array');
     }


### PR DESCRIPTION
- Bump version to 0.1.3
- Add schemaOnly option to MCPCore constructor
- Auto-discover all tool classes in tools directory recursively
- Extract tool schemas directly from existing tool class definitions
- Update getAvailableTools() to support schema-only mode
- Prevent tool execution in schema-only mode with clear errors
- Enable internal library usage without VM_MCP_TOKEN requirement
- Maintain single source of truth for tool definitions
- Enhance error handling in index.js to provide more informative messages for network/API connection issues and Node.js compatibility checks.
- Update tokenValidator.js and vmApiClient.js to reflect the new default API base URL for improved clarity and consistency.