### PR TITLE
feat(mcp): add product feedback submission tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villagemetrics-public/ask-anything-mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Model Context Protocol server for Village Metrics behavioral tracking data access",
   "type": "module",
   "main": "src/lib/index.js",

--- a/scripts/generate-example-responses.js
+++ b/scripts/generate-example-responses.js
@@ -161,6 +161,17 @@ const TOOLS = [
       name: 'list_village_members',
       arguments: { includeInvitationDetails: true }
     }
+  },
+  {
+    name: 'Submit Product Feedback',
+    method: 'tools/call',
+    params: {
+      name: 'submit_product_feedback',
+      arguments: { 
+        feedbackText: 'The Ask Anything MCP tool is working great! This is an example feedback submission for documentation purposes.',
+        source: 'ask-anything'
+      }
+    }
   }
 ];
 

--- a/src/clients/vmApiClient.js
+++ b/src/clients/vmApiClient.js
@@ -308,4 +308,21 @@ export class VMApiClient {
       throw error;
     }
   }
+
+  async submitProductFeedback(feedbackText, source = 'ask-anything') {
+    try {
+      const response = await this.client.post('/v1/product-feedback', {
+        feedbackText,
+        source
+      });
+      logger.debug('Product feedback API response received', { 
+        success: response.data?.success,
+        source,
+        feedbackLength: feedbackText?.length || 0
+      });
+      return response.data;
+    } catch (error) {
+      throw error;
+    }
+  }
 }

--- a/src/tools/feedback/submitProductFeedback.js
+++ b/src/tools/feedback/submitProductFeedback.js
@@ -1,0 +1,93 @@
+import { createLogger } from '../../utils/logger.js';
+import { VMApiClient } from '../../clients/vmApiClient.js';
+
+const logger = createLogger('SubmitProductFeedbackTool');
+
+export class SubmitProductFeedbackTool {
+  constructor(sessionManager, apiOptions = {}) {
+    this.sessionManager = sessionManager;
+    this.apiClient = new VMApiClient(apiOptions);
+  }
+
+  static get definition() {
+    return {
+      name: 'submit_product_feedback',
+      description: 'Submit feedback about Village Metrics features, functionality, or user experience. Use this to share suggestions, report issues, or provide general feedback about the application.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          feedbackText: {
+            type: 'string',
+            description: 'Your feedback about the product. This can include feature requests, bug reports, suggestions for improvement, or general comments about your experience with Village Metrics.',
+            minLength: 1,
+            maxLength: 10000
+          },
+          source: {
+            type: 'string',
+            enum: ['ask-anything', 'journal-entry', 'general'],
+            description: 'The source context for this feedback. Use "ask-anything" for feedback related to this AI assistant, "journal-entry" for feedback about journal features, or "general" for other feedback.',
+            default: 'ask-anything'
+          }
+        },
+        required: ['feedbackText']
+      }
+    };
+  }
+
+  async execute(args, session) {
+    try {
+      const { feedbackText, source = 'ask-anything' } = args;
+
+      // Validate feedback text length
+      if (!feedbackText || feedbackText.trim().length === 0) {
+        throw new Error('Feedback text is required and cannot be empty');
+      }
+
+      if (feedbackText.length > 10000) {
+        throw new Error('Feedback text must be less than 10,000 characters');
+      }
+
+      logger.info('Submitting product feedback', { 
+        userId: session.userId, 
+        source,
+        feedbackLength: feedbackText.length 
+      });
+
+      // Submit feedback to API
+      const response = await this.apiClient.submitProductFeedback(feedbackText.trim(), source);
+
+      logger.info('Product feedback submitted successfully', { 
+        userId: session.userId, 
+        source,
+        success: response.success 
+      });
+
+      return {
+        success: true,
+        message: 'Thank you for your feedback! Your input has been submitted to the Village Metrics team and will help us improve the application.',
+        submissionDetails: {
+          source,
+          feedbackLength: feedbackText.trim().length,
+          submittedAt: new Date().toISOString()
+        }
+      };
+    } catch (error) {
+      logger.error('Failed to submit product feedback', { 
+        error: error.message,
+        userId: session.userId,
+        source: args?.source
+      });
+      
+      // Provide user-friendly error messages
+      if (error.response?.status === 400) {
+        throw new Error(`Feedback validation error: ${error.message}`);
+      } else if (error.response?.status === 401) {
+        throw new Error('Authentication failed. Please check your connection and try again.');
+      } else if (error.response?.status === 500) {
+        throw new Error('Server error occurred while submitting feedback. Please try again later.');
+      } else {
+        throw new Error(`Failed to submit feedback: ${error.message}`);
+      }
+    }
+  }
+}

--- a/src/tools/registry.js
+++ b/src/tools/registry.js
@@ -22,6 +22,8 @@ import { GetMedicationDetailedAnalysisTool } from './analysis/getMedicationDetai
 import { GetVersionInfoTool } from './system/getVersionInfo.js';
 // Help tools
 import { GetProductHelpTool } from './help/getProductHelp.js';
+// Feedback tools
+import { SubmitProductFeedbackTool } from './feedback/submitProductFeedback.js';
 
 const logger = createLogger('ToolRegistry');
 
@@ -57,6 +59,8 @@ export class ToolRegistry {
       getVersionInfo: new GetVersionInfoTool(autoUpdater),
       // Help tools
       getProductHelp: new GetProductHelpTool(sessionManager, apiOptions),
+      // Feedback tools
+      submitProductFeedback: new SubmitProductFeedbackTool(sessionManager, apiOptions),
       // Future tools will be added here:
       // Math tools
     };
@@ -97,6 +101,9 @@ export class ToolRegistry {
     
     // Register help tools
     this.registerToolClass(GetProductHelpTool, this.toolInstances.getProductHelp);
+    
+    // Register feedback tools
+    this.registerToolClass(SubmitProductFeedbackTool, this.toolInstances.submitProductFeedback);
     
     logger.info('Tools registered', { count: this.tools.size });
   }

--- a/test/tools/submitProductFeedback.test.js
+++ b/test/tools/submitProductFeedback.test.js
@@ -1,0 +1,217 @@
+import { expect } from 'chai';
+import { SubmitProductFeedbackTool } from '../../src/tools/feedback/submitProductFeedback.js';
+
+describe('Submit Product Feedback Tool', () => {
+  let tool;
+  let mockSessionManager;
+  let mockApiClient;
+
+  beforeEach(() => {
+    mockSessionManager = {};
+    mockApiClient = {
+      submitProductFeedback: async (feedbackText, source) => ({
+        success: true,
+        message: 'Product feedback submitted successfully'
+      })
+    };
+    
+    tool = new SubmitProductFeedbackTool(mockSessionManager);
+    tool.apiClient = mockApiClient; // Override with mock
+  });
+
+  describe('Tool Definition', () => {
+    it('should have correct tool definition', () => {
+      const definition = SubmitProductFeedbackTool.definition;
+      
+      expect(definition.name).to.equal('submit_product_feedback');
+      expect(definition.description).to.include('Submit feedback about Village Metrics');
+      expect(definition.inputSchema.properties.feedbackText).to.exist;
+      expect(definition.inputSchema.properties.source).to.exist;
+      expect(definition.inputSchema.required).to.deep.equal(['feedbackText']);
+    });
+
+    it('should have correct source enum values', () => {
+      const definition = SubmitProductFeedbackTool.definition;
+      const sourceEnum = definition.inputSchema.properties.source.enum;
+      
+      expect(sourceEnum).to.deep.equal(['ask-anything', 'journal-entry', 'general']);
+      expect(definition.inputSchema.properties.source.default).to.equal('ask-anything');
+    });
+
+    it('should have correct feedbackText constraints', () => {
+      const definition = SubmitProductFeedbackTool.definition;
+      const feedbackText = definition.inputSchema.properties.feedbackText;
+      
+      expect(feedbackText.minLength).to.equal(1);
+      expect(feedbackText.maxLength).to.equal(10000);
+    });
+  });
+
+  describe('Input Validation', () => {
+    it('should require feedbackText parameter', async () => {
+      try {
+        await tool.execute({}, { userId: 'test-user' });
+        expect.fail('Should have thrown error');
+      } catch (error) {
+        expect(error.message).to.include('Feedback text is required');
+      }
+    });
+
+    it('should reject empty feedbackText', async () => {
+      try {
+        await tool.execute({ feedbackText: '   ' }, { userId: 'test-user' });
+        expect.fail('Should have thrown error');
+      } catch (error) {
+        expect(error.message).to.include('Feedback text is required');
+      }
+    });
+
+    it('should reject feedbackText that is too long', async () => {
+      const longText = 'a'.repeat(10001);
+      try {
+        await tool.execute({ feedbackText: longText }, { userId: 'test-user' });
+        expect.fail('Should have thrown error');
+      } catch (error) {
+        expect(error.message).to.include('less than 10,000 characters');
+      }
+    });
+  });
+
+  describe('Successful Execution', () => {
+    it('should submit feedback with default source', async () => {
+      let capturedFeedback, capturedSource;
+      mockApiClient.submitProductFeedback = async (feedbackText, source) => {
+        capturedFeedback = feedbackText;
+        capturedSource = source;
+        return { success: true, message: 'Feedback submitted successfully' };
+      };
+
+      const result = await tool.execute({
+        feedbackText: 'Great product!'
+      }, { userId: 'test-user' });
+
+      expect(capturedFeedback).to.equal('Great product!');
+      expect(capturedSource).to.equal('ask-anything');
+      expect(result.success).to.be.true;
+      expect(result.message).to.include('Thank you for your feedback');
+      expect(result.submissionDetails.source).to.equal('ask-anything');
+      expect(result.submissionDetails.feedbackLength).to.equal(14);
+    });
+
+    it('should submit feedback with specified source', async () => {
+      let capturedFeedback, capturedSource;
+      mockApiClient.submitProductFeedback = async (feedbackText, source) => {
+        capturedFeedback = feedbackText;
+        capturedSource = source;
+        return { success: true, message: 'Feedback submitted successfully' };
+      };
+
+      const result = await tool.execute({
+        feedbackText: 'The journal feature is excellent!',
+        source: 'journal-entry'
+      }, { userId: 'test-user' });
+
+      expect(capturedFeedback).to.equal('The journal feature is excellent!');
+      expect(capturedSource).to.equal('journal-entry');
+      expect(result.success).to.be.true;
+      expect(result.submissionDetails.source).to.equal('journal-entry');
+    });
+
+    it('should trim whitespace from feedback text', async () => {
+      let capturedFeedback;
+      mockApiClient.submitProductFeedback = async (feedbackText, source) => {
+        capturedFeedback = feedbackText;
+        return { success: true, message: 'Feedback submitted successfully' };
+      };
+
+      const result = await tool.execute({
+        feedbackText: '   Feedback with spaces   '
+      }, { userId: 'test-user' });
+
+      expect(capturedFeedback).to.equal('Feedback with spaces');
+      expect(result.submissionDetails.feedbackLength).to.equal(20);
+    });
+
+    it('should include submission timestamp', async () => {
+      const beforeTime = new Date();
+      
+      const result = await tool.execute({
+        feedbackText: 'Test feedback'
+      }, { userId: 'test-user' });
+
+      const afterTime = new Date();
+      const submittedAt = new Date(result.submissionDetails.submittedAt);
+      
+      expect(submittedAt).to.be.at.least(beforeTime);
+      expect(submittedAt).to.be.at.most(afterTime);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle 400 validation errors', async () => {
+      mockApiClient.submitProductFeedback = async () => {
+        const error = new Error('Invalid request');
+        error.response = { status: 400 };
+        throw error;
+      };
+
+      try {
+        await tool.execute({
+          feedbackText: 'Test feedback'
+        }, { userId: 'test-user' });
+        expect.fail('Should have thrown error');
+      } catch (error) {
+        expect(error.message).to.include('Feedback validation error');
+      }
+    });
+
+    it('should handle 401 authentication errors', async () => {
+      mockApiClient.submitProductFeedback = async () => {
+        const error = new Error('Unauthorized');
+        error.response = { status: 401 };
+        throw error;
+      };
+
+      try {
+        await tool.execute({
+          feedbackText: 'Test feedback'
+        }, { userId: 'test-user' });
+        expect.fail('Should have thrown error');
+      } catch (error) {
+        expect(error.message).to.include('Authentication failed');
+      }
+    });
+
+    it('should handle 500 server errors', async () => {
+      mockApiClient.submitProductFeedback = async () => {
+        const error = new Error('Internal server error');
+        error.response = { status: 500 };
+        throw error;
+      };
+
+      try {
+        await tool.execute({
+          feedbackText: 'Test feedback'
+        }, { userId: 'test-user' });
+        expect.fail('Should have thrown error');
+      } catch (error) {
+        expect(error.message).to.include('Server error occurred');
+      }
+    });
+
+    it('should handle generic network errors', async () => {
+      mockApiClient.submitProductFeedback = async () => {
+        throw new Error('Network error');
+      };
+
+      try {
+        await tool.execute({
+          feedbackText: 'Test feedback'
+        }, { userId: 'test-user' });
+        expect.fail('Should have thrown error');
+      } catch (error) {
+        expect(error.message).to.include('Failed to submit feedback: Network error');
+      }
+    });
+  });
+});


### PR DESCRIPTION
- Add submit_product_feedback tool to MCP interface
- Integrate with deployed /v1/product-feedback API endpoint
- Add VMApiClient.submitProductFeedback() method
- Include comprehensive test suite (14 passing tests)
- Update example generation script with new tool
- Support feedbackText and source parameters (defaults to "ask-anything")