### PR TITLE
Rename get_journal_entry_details to get_journal_entry_analysis and add shortTitle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villagemetrics-public/ask-anything-mcp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Model Context Protocol server for Village Metrics behavioral tracking data access",
   "type": "module",
   "main": "src/lib/index.js",

--- a/src/tools/journal/getJournalDetails.js
+++ b/src/tools/journal/getJournalDetails.js
@@ -11,8 +11,8 @@ export class GetJournalDetailsTool {
 
   static get definition() {
     return {
-      name: 'get_journal_entry_details',
-      description: 'Get additional detailed analysis of a journal entry. Returns DIFFERENT data than get_journal_entry: BCBA professional analysis, per-goal behavior scores (1-4 scale) with reasoning, child profile (likes/dislikes/strengths), detailed hashtag metrics, and all scoring metrics. Call get_journal_entry first for basic content.',
+      name: 'get_journal_entry_analysis',
+      description: 'Get detailed analysis of a single journal entry. Returns DIFFERENT data than get_journal_entry: BCBA professional analysis, per-goal behavior scores (1-4 scale) with reasoning, child profile (likes/dislikes/strengths), detailed hashtag metrics, and all scoring metrics. Call get_journal_entry first for basic content.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -65,6 +65,7 @@ export class GetJournalDetailsTool {
     return {
       childName,
       journalEntryId: entry.journalEntryId,
+      shortTitle: results.shortTitle || '',
       date: entry.date,
       
       // BCBA Analysis

--- a/test/tools/toolRegistry.test.js
+++ b/test/tools/toolRegistry.test.js
@@ -52,7 +52,7 @@ describe('Tool Registry', function() {
       expect(toolNames).to.include('get_date_range_metadata');
       expect(toolNames).to.include('search_journal_entries');
       expect(toolNames).to.include('get_journal_entry');
-      expect(toolNames).to.include('get_journal_entry_details');
+      expect(toolNames).to.include('get_journal_entry_analysis');
       
       // Analysis tools
       expect(toolNames).to.include('get_overview_analysis');


### PR DESCRIPTION
- Renamed tool to avoid confusion with existing get_journal_analysis
- Added shortTitle field to match get_journal_entry output