### PR TITLE
Add auth token debugging for processor 401 troubleshooting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villagemetrics-public/ask-anything-mcp",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Model Context Protocol server for Village Metrics behavioral tracking data access",
   "type": "module",
   "main": "src/lib/index.js",

--- a/src/clients/vmApiClient.js
+++ b/src/clients/vmApiClient.js
@@ -86,7 +86,12 @@ export class VMApiClient {
       baseUrl: this.baseUrl, 
       tokenType: this.tokenType,
       hasToken: !!this.token,
-      tokenLength: this.token?.length || 0
+      tokenLength: this.token?.length || 0,
+      tokenSource: options.authToken ? 'options.authToken' : 
+                   options.mcpToken ? 'options.mcpToken' :
+                   process.env.VM_AUTH_TOKEN ? 'VM_AUTH_TOKEN env var' :
+                   process.env.VM_MCP_TOKEN ? 'VM_MCP_TOKEN env var' : 'unknown',
+      tokenPrefix: this.token?.substring(0, 20) + '...' || 'none'
     });
   }
 

--- a/src/lib/mcpCore.js
+++ b/src/lib/mcpCore.js
@@ -52,6 +52,14 @@ export class MCPCore {
         apiOptions.mcpToken = this.options.mcpToken;
       }
       
+      logger.debug('MCPCore passing apiOptions to ToolRegistry', {
+        tokenType: apiOptions.tokenType,
+        hasAuthToken: !!apiOptions.authToken,
+        hasMcpToken: !!apiOptions.mcpToken,
+        authTokenLength: apiOptions.authToken?.length || 0,
+        authTokenPrefix: apiOptions.authToken?.substring(0, 20) + '...' || 'none'
+      });
+      
       this.toolRegistry = new ToolRegistry(this.sessionManager, null, apiOptions, this.options);
       
       // Pre-populate session if user context provided


### PR DESCRIPTION
- Add debug logs to MCPCore showing apiOptions passed to ToolRegistry
- Add debug logs to VMApiClient showing token source, length, and prefix
- Helps trace authToken flow from ask-anything-processor to VM API