### PR TITLE
feat(analysis): surface previous-period date range in analysis output (v1.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villagemetrics-public/ask-anything-mcp",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Model Context Protocol server for Village Metrics behavioral tracking data access",
   "type": "module",
   "main": "src/lib/index.js",

--- a/src/transformers/analysisData.js
+++ b/src/transformers/analysisData.js
@@ -111,6 +111,13 @@ export function transformOverviewAnalysis(rawData, childName, timeRange) {
     result.dateRange = { startDate, endDate };
   }
 
+  // Add previous period date range if available (for trend comparison context)
+  if (rawData.analysisMeta?.previousPeriodDateRange) {
+    const prevStartDate = new Date(rawData.analysisMeta.previousPeriodDateRange.startDate).toLocaleDateString();
+    const prevEndDate = new Date(rawData.analysisMeta.previousPeriodDateRange.endDate).toLocaleDateString();
+    result.previousPeriodDateRange = { startDate: prevStartDate, endDate: prevEndDate };
+  }
+
   // Add overall behavior score (from analysisData.overallBehavior)
   if (rawData.analysisData?.overallBehavior) {
     const behavior = rawData.analysisData.overallBehavior;
@@ -119,7 +126,8 @@ export function transformOverviewAnalysis(rawData, childName, timeRange) {
       previousScore: behavior.previousPeriodScore,
       scoreChange: behavior.scoreChange,
       daysWithData: behavior.daysWithData,
-      _scoreRange: "Behavior scores range from 1 (very challenging day) to 4 (excellent day). Higher scores indicate better behavior."
+      _scoreRange: "Behavior scores range from 1 (very challenging day) to 4 (excellent day). Higher scores indicate better behavior.",
+      _previousScoreNote: "previousScore is the average for the prior period shown in previousPeriodDateRange (same duration, ending the day before the current period starts)"
     };
   }
 
@@ -213,6 +221,13 @@ export function transformBehaviorAnalysis(rawAnalysisData, rawGoalsData, childNa
     result.dateRange = { startDate, endDate };
   }
 
+  // Add previous period date range if available (for trend comparison context)
+  if (rawAnalysisData?.analysisMeta?.previousPeriodDateRange) {
+    const prevStartDate = new Date(rawAnalysisData.analysisMeta.previousPeriodDateRange.startDate).toLocaleDateString();
+    const prevEndDate = new Date(rawAnalysisData.analysisMeta.previousPeriodDateRange.endDate).toLocaleDateString();
+    result.previousPeriodDateRange = { startDate: prevStartDate, endDate: prevEndDate };
+  }
+
   // Note: We don't include behaviorGoals separately as they're included in behaviorGoalAnalysis below to avoid duplication
 
   // Add overall behavior with score context
@@ -223,7 +238,8 @@ export function transformBehaviorAnalysis(rawAnalysisData, rawGoalsData, childNa
       previousScore: behavior.previousPeriodScore,
       scoreChange: behavior.scoreChange,
       daysWithData: behavior.daysWithData,
-      _scoreRange: "Behavior scores range from 1 (very challenging day) to 4 (excellent day). Higher scores indicate better behavior."
+      _scoreRange: "Behavior scores range from 1 (very challenging day) to 4 (excellent day). Higher scores indicate better behavior.",
+      _previousScoreNote: "previousScore is the average for the prior period shown in previousPeriodDateRange (same duration, ending the day before the current period starts)"
     };
   }
 
@@ -234,6 +250,7 @@ export function transformBehaviorAnalysis(rawAnalysisData, rawGoalsData, childNa
       averageScore: goal.averageScore,
       previousScore: goal.previousPeriodScore,
       scoreChange: goal.scoreChange,
+      _previousScoreNote: "previousScore is the average for the prior period shown in previousPeriodDateRange",
       whatWorks: goal.whatWorks?.map(item => ({
         hashtag: item.hashtag,
         averageScore: item.averageScore,

--- a/test/transformers/analysisData.test.js
+++ b/test/transformers/analysisData.test.js
@@ -1,0 +1,122 @@
+import { expect } from 'chai';
+import {
+  transformOverviewAnalysis,
+  transformBehaviorAnalysis
+} from '../../src/transformers/analysisData.js';
+
+// Pure-function unit tests for the analysis transformers. These exercise the
+// previous-period-date-range surfacing without hitting the API, using synthetic
+// rawData objects shaped exactly like the analysis-job-processor output
+// (analysisMeta.previousPeriodDateRange, produced by AnalysisContext.toMetadata()).
+
+describe('analysisData transformers - previous period context', function() {
+  const childName = 'Test Child';
+
+  describe('transformOverviewAnalysis', function() {
+    it('surfaces previousPeriodDateRange when present in analysisMeta', function() {
+      const rawData = {
+        analysisMeta: {
+          dateRange: { startDate: '2025-09-05', endDate: '2025-12-03' },
+          previousPeriodDateRange: { startDate: '2025-06-08', endDate: '2025-09-04' }
+        },
+        analysisData: {
+          overallBehavior: {
+            averageScore: 3.13,
+            previousPeriodScore: 2.78,
+            scoreChange: 0.35,
+            daysWithData: 8
+          }
+        }
+      };
+
+      const result = transformOverviewAnalysis(rawData, childName, 'last_90_days');
+
+      expect(result.previousPeriodDateRange).to.exist;
+      expect(result.previousPeriodDateRange.startDate).to.be.a('string').and.contain('2025');
+      expect(result.previousPeriodDateRange.endDate).to.be.a('string').and.contain('2025');
+      // The current dateRange should still be surfaced alongside it
+      expect(result.dateRange).to.exist;
+      // The explanatory note that references previousPeriodDateRange should be present
+      expect(result.overallBehavior._previousScoreNote).to.contain('previousPeriodDateRange');
+      expect(result.overallBehavior.previousScore).to.equal(2.78);
+    });
+
+    it('omits previousPeriodDateRange gracefully when absent (no crash)', function() {
+      const rawData = {
+        analysisMeta: {
+          dateRange: { startDate: '2025-10-22', endDate: '2025-11-20' }
+          // no previousPeriodDateRange (e.g. insufficient history for last_30_days)
+        },
+        analysisData: {
+          overallBehavior: {
+            averageScore: 3.11,
+            previousPeriodScore: 3.25,
+            scoreChange: -0.14,
+            daysWithData: 5
+          }
+        }
+      };
+
+      const result = transformOverviewAnalysis(rawData, childName, 'last_30_days');
+
+      expect(result.previousPeriodDateRange).to.be.undefined;
+      expect(result.dateRange).to.exist;
+      // previousScore is still present even when the range isn't, so the note stays useful
+      expect(result.overallBehavior.previousScore).to.equal(3.25);
+    });
+  });
+
+  describe('transformBehaviorAnalysis', function() {
+    it('surfaces previousPeriodDateRange and per-goal note when present', function() {
+      const rawAnalysisData = {
+        analysisMeta: {
+          dateRange: { startDate: '2025-09-05', endDate: '2025-12-03' },
+          previousPeriodDateRange: { startDate: '2025-06-08', endDate: '2025-09-04' }
+        },
+        analysisData: {
+          overallBehavior: {
+            averageScore: 3.13,
+            previousPeriodScore: 2.78,
+            scoreChange: 0.35,
+            daysWithData: 8
+          },
+          behaviorGoals: [
+            {
+              name: 'Maintained Safety',
+              averageScore: 3.38,
+              previousPeriodScore: 3.0,
+              scoreChange: 0.38,
+              whatWorks: [],
+              whatNotWorks: []
+            }
+          ]
+        }
+      };
+
+      const result = transformBehaviorAnalysis(rawAnalysisData, [], childName, 'last_90_days');
+
+      expect(result.previousPeriodDateRange).to.exist;
+      expect(result.previousPeriodDateRange.startDate).to.be.a('string').and.contain('2025');
+      expect(result.previousPeriodDateRange.endDate).to.be.a('string').and.contain('2025');
+      expect(result.behaviorGoalAnalysis).to.have.lengthOf(1);
+      expect(result.behaviorGoalAnalysis[0].previousScore).to.equal(3.0);
+      expect(result.behaviorGoalAnalysis[0]._previousScoreNote).to.contain('previousPeriodDateRange');
+    });
+
+    it('omits previousPeriodDateRange gracefully when absent (no crash)', function() {
+      const rawAnalysisData = {
+        analysisMeta: {
+          dateRange: { startDate: '2025-10-22', endDate: '2025-11-20' }
+        },
+        analysisData: {
+          behaviorGoals: []
+        }
+      };
+
+      const result = transformBehaviorAnalysis(rawAnalysisData, [], childName, 'last_30_days');
+
+      expect(result.previousPeriodDateRange).to.be.undefined;
+      expect(result.dateRange).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
## What

Surfaces the **previous-period date range** and explanatory score notes in the overview and behavior analysis transforms so LLM consumers know exactly what window `previousScore` / `scoreChange` are measured against.

Adds to `transformOverviewAnalysis` and `transformBehaviorAnalysis`:
- `previousPeriodDateRange: { startDate, endDate }` — the prior comparison window (same duration, ending the day before the current period), surfaced from `analysisMeta.previousPeriodDateRange`.
- `_previousScoreNote` on `overallBehavior` and each `behaviorGoalAnalysis` entry, explaining what `previousScore` refers to.

## Why

Previously the model saw e.g. `previousScore: 2.78` with no idea which dates that covered, making trend answers vague or prone to inventing the comparison window. Now the assistant can say "compared to Jun 8 – Sep 4" concretely.

## Behavior / safety

- Purely **additive** — no existing fields changed or removed.
- Guarded with optional chaining. When the producer doesn't emit `previousPeriodDateRange` (e.g. insufficient history for `last_30_days`), the field is simply absent — no error, graceful degradation.
- Data shape matches the producer exactly: `analysis-job-processor`'s `AnalysisContext.toMetadata()` emits `analysisMeta.previousPeriodDateRange.{startDate,endDate}`.

## Verification

- Exercised end-to-end against the real dev API: `last_90_days` correctly yields prior window `6/8/2025 → 9/4/2025` for current `9/5 → 12/3`; `last_30_days` degrades gracefully to absent.
- 28 existing analysis integration tests pass; added 4 focused pure-function unit tests (`test/transformers/analysisData.test.js`) covering present/absent cases.
- develop CI green.

## Release

- Version bumped `1.0.3 → 1.1.0` (backward-compatible feature). Required — the publish workflow hard-fails on main without a bump.
- Merging to main publishes `1.1.0` to npm; the auto-updater propagates it to installed MCP servers.
- Consumer `ask-anything-engine` (`^1.0.2`) will pick up `1.1.0` on its next install/update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
