### PR TITLE
ci: switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,7 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'villagemetrics/ask-anything-mcp' && github.ref == 'refs/heads/main'
     needs: test
-    
+    permissions:
+      contents: read
+      id-token: write # Required for npm trusted publishing (OIDC)
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -42,7 +45,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm (trusted publishing requires npm >= 11.5.1)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -53,23 +58,12 @@ jobs:
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
 
-          # Check if version was bumped from previous commit
-          git fetch origin main --depth=2
-          PREV_VERSION=$(git show HEAD~1:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf-8')).version")
-
-          if [ "$PACKAGE_VERSION" = "$PREV_VERSION" ]; then
-            echo "❌ ERROR: Version not bumped!"
-            echo "Current version: $PACKAGE_VERSION"
-            echo "Previous version: $PREV_VERSION"
-            echo "You must bump the version in package.json when making code changes."
-            exit 1
-          fi
-
-          # Check if this version exists on npm
+          # The npm registry is the ground truth: publish only if this exact
+          # version isn't there yet. Same-version commits (docs, workflow
+          # changes) skip publish gracefully instead of failing the build.
           if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version 2>/dev/null; then
-            echo "❌ ERROR: Version $PACKAGE_VERSION already exists on npm"
-            echo "This shouldn't happen if version was properly bumped."
-            exit 1
+            echo "⚠️ Version $PACKAGE_VERSION already exists on npm, skipping publish"
+            echo "should_publish=false" >> $GITHUB_OUTPUT
           else
             echo "✅ Version $PACKAGE_VERSION not found on npm, will publish"
             echo "should_publish=true" >> $GITHUB_OUTPUT
@@ -78,11 +72,9 @@ jobs:
           echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
           echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Publish to NPM
+      - name: Publish to NPM (trusted publishing, no token)
         if: steps.check_version.outputs.should_publish == 'true'
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Notify success
         if: steps.check_version.outputs.should_publish == 'true'

--- a/docs/npm-publishing-setup.md
+++ b/docs/npm-publishing-setup.md
@@ -1,0 +1,16 @@
+# NPM Publishing Setup (Trusted Publishing / OIDC)
+
+How `@villagemetrics-public/ask-anything-mcp` gets published to the public npm registry, and how to troubleshoot it.
+
+## How it works
+
+- **Registry:** public npmjs.org (`publishConfig.registry` in `package.json`). This package is intentionally public — end users install it for Claude Desktop, and the built-in auto-updater polls npmjs for new versions. (Contrast: internal `@villagemetrics/*` packages like `user-data-client` publish privately to GitHub Packages instead.)
+- **Trigger:** merging/pushing to `main` runs `.github/workflows/npm-publish.yml`. The `test` job runs on both `develop` and `main`; the `publish` job runs only on `main`.
+- **Auth: npm Trusted Publishing (OIDC) — there is no NPM_TOKEN.** The GitHub Actions workflow proves its identity to npm directly via OIDC. Nothing expires, nothing to rotate. Configured on npmjs.com under the package's Settings → Trusted Publisher: org `villagemetrics`, repo `ask-anything-mcp`, workflow `npm-publish.yml`, no environment. Requirements in the workflow: `permissions: id-token: write` on the publish job and npm CLI >= 11.5.1 (hence the `npm install -g npm@latest` step).
+- **Version gate:** the workflow publishes only if `package.json`'s version does not already exist on npm. Same-version commits to main (docs, workflow tweaks) skip publish gracefully — they don't fail the build. Remember to bump the version in `package.json` when shipping code changes, or nothing will be published.
+
+## History / troubleshooting
+
+- **Pre-July 2026** this used an `NPM_TOKEN` repo secret (classic/granular npm token). It expired silently (npm's late-2025 security changes capped token lifetimes), and publishes started failing with `npm error code E404: Not Found - PUT ...` — npm masks authorization failures on publish as 404 to avoid leaking package existence. If you ever see **E404 on PUT** during publish, think *auth*, not *missing package*.
+- The old workflow also hard-failed if the version wasn't bumped relative to the previous commit; that made any same-version commit to main fail CI and was replaced by the graceful registry-ground-truth check described above.
+- If publish fails with an OIDC/auth error, verify the Trusted Publisher config on npmjs.com still matches the repo/workflow filename exactly (renaming the workflow file breaks it).


### PR DESCRIPTION
Replaces the expired NPM_TOKEN with npm Trusted Publishing (OIDC) — no token, nothing to expire. Trusted publisher is already configured on npmjs.com for this repo/workflow. Also: version gate now checks the npm registry (ground truth) and skips gracefully instead of hard-failing on same-version commits. Adds docs/npm-publishing-setup.md. Merging this publishes v1.1.0 (already on main, blocked by the dead token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)