### PR TITLE
ci: use Node 24 in publish job

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Update npm (trusted publishing requires npm >= 11.5.1)
         run: npm install -g npm@latest


### PR DESCRIPTION
Fixes the OIDC publish: npm@12 (latest) requires Node >=22; publish job was on Node 20. Merging publishes v1.1.0 via trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)