### PR TITLE
ci: drop npm self-upgrade, use Node 24 bundled npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
+          # Node 24 bundles npm >= 11.6, which satisfies trusted publishing's
+          # npm >= 11.5.1 requirement. Do not npm install -g npm@latest here -
+          # npm overwriting itself on the runner corrupts the install.
           node-version: '24'
-
-      - name: Update npm (trusted publishing requires npm >= 11.5.1)
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
npm@latest self-upgrade corrupted the runner's npm (missing sigstore module). Node 24 bundles npm 11.6+ which already satisfies trusted publishing's >=11.5.1 requirement. Merging publishes v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)